### PR TITLE
fix: change supported harvester networks

### DIFF
--- a/vault-harvester/.env.example
+++ b/vault-harvester/.env.example
@@ -1,5 +1,4 @@
 ETHERSCAN_API_KEY=ABC123ABC123ABC123ABC123ABC123ABC1
-KOVAN_URL=https://kovan.infura.io/v3/<YOUR INFURA KEY>
-RINKEBY_URL=https://eth-ropsten.alchemyapi.io/v2/<YOUR ALCHEMY KEY>
+GOERLI_URL=https://goerli.infura.io/v3/<YOUR INFURA KEY>
 MUMBAI_URL=https://polygon-mumbai.g.alchemy.com/v2/<YOUR ALCHEMY KEY>
 PRIVATE_KEY=0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1

--- a/vault-harvester/hardhat.config.ts
+++ b/vault-harvester/hardhat.config.ts
@@ -38,13 +38,8 @@ const config: HardhatUserConfig = {
   },
   networks: {
     hardhat: {},
-    kovan: {
-      url: process.env.KOVAN_URL || "",
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-    },
-    rinkeby: {
-      url: process.env.RINKEBY_URL || "",
+    goerli: {
+      url: process.env.GOERLI_URL || "",
       accounts:
         process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
     },


### PR DESCRIPTION
In addition to this #121 that changes networks only for the batch-reveal, this PR changes the supported networks for the vault-harvester too. 